### PR TITLE
Add eslint-plugin-security config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 # @dendavidov/eslint-config-react
 
 Opinionated eslint-config for React.js SPA.
+Includes security best-practice rules via `eslint-plugin-security`.
 
 ## Installation
 
@@ -17,6 +18,7 @@ npm i -D @dendavidov/eslint-config-react
 ## Usage
 
 Create `eslint.config.js` in the root of your project:
+
 ```javascript
 import config from '@dendavidov/eslint-config-react';
 
@@ -24,6 +26,7 @@ export default config;
 ```
 
 Or extend with your own rules:
+
 ```javascript
 import config from '@dendavidov/eslint-config-react';
 
@@ -32,12 +35,13 @@ export default [
   {
     rules: {
       // Your custom rules
-    }
-  }
+    },
+  },
 ];
 ```
 
 Add script to package.json:
+
 ```json
 {
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-jest": "^29.0.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-testing-library": "^7.5.4",
         "husky": "^9.1.7",
         "jest": "^30.0.4",
@@ -40,6 +41,7 @@
         "eslint-plugin-jest": "^29.0.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-testing-library": "^7.5.4"
       }
     },
@@ -6075,6 +6077,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-security": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
+      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -13904,6 +13922,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -14091,6 +14119,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-testing-library": "^7.5.4"
+    "eslint-plugin-testing-library": "^7.5.4",
+    "eslint-plugin-security": "^3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
@@ -63,6 +64,7 @@
     "eslint-plugin-testing-library": "^7.5.4",
     "husky": "^9.1.7",
     "jest": "^30.0.4",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "eslint-plugin-security": "^3.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import reactPlugin from 'eslint-plugin-react';
 import importPlugin from 'eslint-plugin-import';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import securityPlugin from 'eslint-plugin-security';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import jestPlugin from 'eslint-plugin-jest';
@@ -11,6 +12,8 @@ import prettierConfig from 'eslint-config-prettier';
 export default [
   // core ESLint recommended
   js.configs.recommended,
+  // Security rules
+  securityPlugin.configs.recommended,
 
   // React configuration
   {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -12,6 +12,12 @@ describe('@dendavidov/eslint-config-react', () => {
     expect(config).toEqual(expect.arrayContaining([jsConfig]));
   });
 
+  it('should include Security plugin configuration', () => {
+    const securityConfig = config.find((c) => c.plugins && c.plugins.security);
+    expect(securityConfig).toBeDefined();
+    expect(securityConfig.rules).toBeDefined();
+  });
+
   it('should include React plugin configuration', () => {
     const reactConfig = config.find((c) => c.plugins && c.plugins.react);
     expect(reactConfig).toBeDefined();


### PR DESCRIPTION
## Summary
- include eslint-plugin-security as a peer/dev dependency
- enable security rules in the main config
- document security plugin usage
- test for security plugin presence

## Testing
- `npm run format:check`
- `npm test`