### PR TITLE
chore: remove redundant .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-node_modules
-.github
-src/index.test.js
-.editorconfig
-.gitignore
-.npmignore
-.prettierrc
-.releaserc.json
-.commitlint.config


### PR DESCRIPTION
## Summary
Remove `.npmignore` file as it's redundant when `package.json` already contains a `files` field.

## Details
- The `files` field in `package.json` already explicitly defines which files should be included in the npm package:
  - `LICENSE`
  - `README.md` 
  - `src/index.js`
  - `src/index.d.ts`
- When a `files` field is present, it takes precedence over `.npmignore`
- Having both can cause confusion and the `.npmignore` file serves no purpose

## Impact
- ✅ No functional changes to the published package
- ✅ Cleaner repository structure
- ✅ Eliminates potential confusion between `.npmignore` and `files` configuration
- ✅ Follows npm best practices for explicit file inclusion

## Testing
Verified that `package.json` `files` field correctly specifies all necessary files for package distribution.