### PR TITLE
build: upgrade CodeQL actions to v3 to fix deprecation warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,6 +71,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## 🔧 Fix Deprecation Warnings

This PR updates the CodeQL GitHub Actions from v2 to v3 to resolve deprecation warnings in our workflow runs.

### 📋 Changes Made
- Updated `github/codeql-action/init@v2` → `@v3`
- Updated `github/codeql-action/autobuild@v2` → `@v3`
- Updated `github/codeql-action/analyze@v2` → `@v3`

### ⚠️ Issues Fixed
1. **Node.js Version Warning**: The v2 actions were using a deprecated Node.js version and were being forced to run on Node 20
2. **CodeQL Action Deprecation**: CodeQL Action v2 will be deprecated on December 5th, 2024

### ✅ Benefits
- Eliminates deprecation warnings from workflow runs
- Ensures future compatibility beyond December 2024
- Uses the latest stable version of CodeQL actions
- Runs on the current Node.js version (Node 20)

### 🧪 Testing
- [x] Workflow syntax validation passes
- [x] No functional changes to security analysis
- [x] All existing CodeQL functionality preserved

### 📚 References
- [GitHub Blog: CodeQL Action v2 Deprecation](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/)
- [GitHub Blog: Node.js Version Update](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)